### PR TITLE
DB session storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,9 @@ gem 'rack-cors'
 # == Job scheduler
 gem 'good_job'
 
+# == Session store
+gem 'activerecord-session_store'
+
 # == Other
 gem 'draper'
 gem 'iso-639'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/uvalib/omniauth-shibboleth.git
-  revision: 3947d3ea743c1b5e1423451986a378b63353d160
+  revision: 9fd262813991dee994752c8a33d2315a97ece3d0
   branch: omniauth2
   specs:
     omniauth-shibboleth (2.0.0)
@@ -67,6 +67,12 @@ GEM
     activerecord (7.0.4.3)
       activemodel (= 7.0.4.3)
       activesupport (= 7.0.4.3)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (7.0.4.3)
       actionpack (= 7.0.4.3)
       activejob (= 7.0.4.3)
@@ -373,6 +379,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store
   archive-zip
   aws-sdk-s3
   bootsnap

--- a/app/jobs/session_cleanup_job.rb
+++ b/app/jobs/session_cleanup_job.rb
@@ -1,0 +1,21 @@
+#
+# app/jobs/session_cleanup_job.rb
+#
+# frozen_string_literal: true
+# warn_indent:           true
+
+__loading_begin(__FILE__)
+
+require "rake"
+
+class SessionCleanupJob < ApplicationJob
+  queue_as :background
+  require "rake"
+  Emma::Application.load_tasks
+
+  def perform(*args, **opt)
+    Rake::Task['db:sessions:trim'].invoke
+  end
+end
+
+__loading_end(__FILE__)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -478,8 +478,8 @@ class User < ApplicationRecord
     data = OmniAuth::AuthHash.new(data) unless data.is_a?(OmniAuth::AuthHash)
     attr = {
       email:         data.uid.downcase,
-      first_name:    data.info&.first_name,
-      last_name:     data.info&.last_name,
+      first_name:    data.info&.first_name || data.info&.givenName,
+      last_name:     data.info&.last_name || data.info&.sn,
       access_token:  (data.credentials&.token         if BS_AUTH),
       refresh_token: (data.credentials&.refresh_token if BS_AUTH),
       provider:      data.provider,

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,9 +43,8 @@ module Emma
     # =========================================================================
 
     config.session_store(
-      :cookie_store,
-      same_site: :lax,
-      key:       "#{railtie_name.chomp('_application')}_session"
+      :active_record_store,
+      key: "#{railtie_name.chomp('_application')}_session"
     )
 
     # =========================================================================

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -30,7 +30,15 @@ Rails.application.config.good_job = {
   execution_mode:
     ENV['GOOD_JOB_EXECUTION_MODE']&.to_sym || :async,
   poll_interval:
-    ENV['GOOD_JOB_POLL_INTERVAL']&.to_f || (application_deployed? ? 1.0 : 0.25)
+    ENV['GOOD_JOB_POLL_INTERVAL']&.to_f || (application_deployed? ? 1.0 : 0.25),
+  enable_cron: true,
+  cron: {
+    session_cleanup: {
+      cron: '0 0 * * *',
+      class: "SessionCleanupJob",
+      description: "Every day run rake db:sessions:trim"
+    }
+  }
 # max_threads:
 #   # NOTE: must be set from config/env_vars.rb
 # queue_string:

--- a/db/migrate/20230605175200_add_sessions_table.rb
+++ b/db/migrate/20230605175200_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/lib/emma/common/exception_methods.rb
+++ b/lib/emma/common/exception_methods.rb
@@ -95,7 +95,7 @@ module Emma::Common::ExceptionMethods
     return unless internal_exception?(error)
     # noinspection RailsParamDefResolve
     if application_deployed? && try(:request)&.format&.html?
-      Log.warn { "EATING INTERNAL EXCEPTION #{error}" }
+      Log.warn { "CREATING INTERNAL EXCEPTION #{error}" }
     else
       Log.warn { "RE-RAISING INTERNAL EXCEPTION #{error}" }
       raise error


### PR DESCRIPTION
Move from Rails' cookie based session storage to DB storage. This will hopefully alleviate issues with the session object being too large and other intermittent session problems.

This gem was added: https://github.com/rails/activerecord-session_store
A migration was created to store sessions in a new table.

It was highly recommended to clear the table periodically to prevent it from growing without limits. A new job was added using GoodJob's cron feature. It will run each night and remove sessions that have not been updated in more than 30 days (this is configurable with SESSION_DAYS_TRIM_THRESHOLD).
The session timeout is an effective way to expire old sessions but works independently of Devise's "timeoutable" feature, which is not being used currently.

